### PR TITLE
Basic extras_require for physio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ opts = dict(name=NAME,
             install_requires=REQUIRES,
             python_requires=PYTHON_REQUIRES,
             setup_requires=SETUP_REQUIRES,
+            extras_require={
+              'physio': ['matplotlib', 'neurokit2', 'bioread']
+            },
             requires=REQUIRES)
 
 


### PR DESCRIPTION
Should be defined in setup.py or setup.cfg or contemporary in pyproject.toml. The yaml files are only for conda and "frozen" to very specific versions